### PR TITLE
Update info on nycflights package

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This package provides the following data tables.
 If you're interested in other subsets of flight data, see:
 
 * [nycflights](https://github.com/jayleetx/nycflights) for flights departing 
-  from NYC in the _last_ year.
+  from NYC in 2017.
   
 * [anyflights](https://github.com/simonpcouch/anyflights) for flights departing
   from any airport in any year.


### PR DESCRIPTION
It doesn't look like it's updated annually, and the current package has 2017 data